### PR TITLE
Node32s-BT_Wristband send pots data with a button

### DIFF
--- a/Ardunio sketch/Node32s-BT_Wristband.ino
+++ b/Ardunio sketch/Node32s-BT_Wristband.ino
@@ -6,37 +6,42 @@ BluetoothSerial SerialBT;
 // LCD Screen Pins
 const int rs = 16; // Digital Pin 16
 const int en = 17; // Digital Pin 17
-const int d4 = 18; // Dijital Pin 18
+const int d4 = 18; // Digital Pin 18
 const int d5 = 19; // Digital Pin 19
 const int d6 = 5;  // Digital Pin 20
 const int d7 = 21; // Digital Pin 21
 
 LiquidCrystal lcd(rs, en, d4, d5, d6, d7);
 
+const int buttonPin = 26; // Digital Pin 26, button pin
+bool sendData = false; // Flag to use for sending data
+
 void setup() {
   SerialBT.begin("SentryESP32"); // Bluetooth device name
   Serial.begin(115200);
 
-  // Define GPIO Pins For Potantiometer
+  // Define GPIO Pins For Potentiometer
   pinMode(34, INPUT);
   pinMode(35, INPUT);
   pinMode(32, INPUT);
   pinMode(33, INPUT);
   pinMode(25, INPUT);
 
- // Set the number of columns and rows of the LCD display (16 columns, 2 rows for 16x2)
+  // Set the button pin as an input with internal pull-up resistor
+  pinMode(buttonPin, INPUT_PULLUP);
+
+  // Initialize the LCD screen
   lcd.begin(16, 2);
 }
 
 void loop() {
- // read potentiometer values
   int potValue1 = analogRead(25);
   int potValue2 = analogRead(33);
   int potValue3 = analogRead(32);
   int potValue4 = analogRead(35);
   int potValue5 = analogRead(34);
 
-  // Clear LCD screen
+  // Clear the LCD screen
   lcd.clear();
 
   // First line
@@ -59,12 +64,16 @@ void loop() {
   lcd.print("k");
   lcd.print(potValue5);
 
-// If a device is connected, send the device name and potentiometer values
- if (SerialBT.hasClient()) {
+  // If a device is connected and the button is pressed, send the data
+  if (SerialBT.hasClient() && digitalRead(buttonPin) == LOW) {
     SerialBT.printf("k1: %d, k2: %d, k3: %d, k4: %d, k5: %d\n", potValue1, potValue2, potValue3, potValue4, potValue5);
+    sendData = true; // Mark data as sent
   }
 
+  // Reset the flag when the button is released to prevent sending data again
+  if (sendData && digitalRead(buttonPin) == HIGH) {
+    sendData = false;
+  }
 
-  // Add Delay
   delay(150);
 }


### PR DESCRIPTION
Instead of sending pot data instantly, it rotates the pots and updates them by pressing a button In this way, instead of reading data continuously, it will read at once and reduce the load.